### PR TITLE
fix: change the boundaries of draggable button

### DIFF
--- a/src/templates/HomeButtonWrapper.jsx.tpl
+++ b/src/templates/HomeButtonWrapper.jsx.tpl
@@ -14,10 +14,6 @@ const styles = {
     zIndex: 1000,
   }
 }
-const bounds = {
-  bottom: 0,
-  right: 0
-}
 const getLocalPosition = () => {
   const position = localStorage.getItem('homeButtonPosition')
   const positionJSON = (position && JSON.parse(position)) || {}
@@ -57,7 +53,7 @@ const HomeButtonProvider = (props) => {
   return (
     <React.Fragment>
       <Draggable
-        bounds={bounds}
+        bounds="body"
         position={position}
         onDrag={onDrag}
         onStop={onStop}


### PR DESCRIPTION
目前可拖拽按钮的边界只对右侧和下侧有设置，因此用户可以向左、向上任意拖拽。
将Draggable的bounds设置为body后可以防止这个问题。
demo: https://codesandbox.io/s/ecstatic-rosalind-niykk